### PR TITLE
Adding Jasmine for testing javascript

### DIFF
--- a/SpecRunner.html
+++ b/SpecRunner.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>Testing with Jasmine</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.css">
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine.min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/jasmine-html.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.8.0/boot.min.js"></script>
+    <script type="module" src="index.js"></script>
+
+    <script type="module" src="indexSpec.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/index.js
+++ b/index.js
@@ -2,26 +2,48 @@ import SiteData from './SiteData.js'
 
 const JSONURL = 'https://spreadsheets.google.com/feeds/list/1nntWrfeSWDfaRAnRjz2CD6VGFnMeKJBYbDqm6i33lr0/od6/public/values?alt=json'
 
-var alertBox = document.getElementById("alert");
-const btn = document.getElementById("submit-button");
-const loading = document.getElementById("loading");
+export function hideLoader() {
+  const loading = document.getElementById("loading");
+  loading.classList.add("hide");
+}
+
+export function redirectTo(location) {
+  document.location = location;
+}
+
+export function findSiteFromInput(data, input) {
+  return data.find(item => item.code === input.value);
+}
+
+function handleSiteNotFound(input, alert) {
+  input.focus();
+  setTimeout(function () {
+    alert.classList.add("visible");
+    window.scrollTo(0, 0);
+  }, 50)
+}
+
+export function handleClickButton(e, data, redirect) {
+  e.preventDefault();
+
+  const alert = document.getElementById("alert");
+  alert.classList.remove("visible");
+
+  const siteCodeInput = document.getElementById("site-id-input");
+  const site = findSiteFromInput(data, siteCodeInput);
+
+  if (site === undefined) {
+    handleSiteNotFound(siteCodeInput, alert)
+  } else {
+    redirect(site.url);
+  }
+}
 
 SiteData(JSONURL).then(data => {
-  var siteCodeInput = document.getElementById("site-id-input");
+  const btn = document.getElementById("submit-button");
   btn.disabled = false;
-  loading.classList.add("hide");
+  hideLoader();
   btn.addEventListener("click", function (e) {
-    e.preventDefault();
-    alertBox.classList.remove("visible");
-    var site = data.find(item => item.code === siteCodeInput.value);
-    if (site === undefined) {
-      siteCodeInput.focus();
-      setTimeout(function () {
-        alertBox.classList.add("visible");
-        window.scrollTo(0, 0);
-      }, 50)
-    } else {
-      document.location = site.url;
-    }
+    handleClickButton(e, data, redirectTo);
   });
 });

--- a/indexSpec.js
+++ b/indexSpec.js
@@ -1,0 +1,86 @@
+import {hideLoader, handleClickButton, findSiteFromInput} from './index.js'
+import {createTestContainer, tearDownTestContainer} from "./specHelper.js";
+
+describe('index.js', () => {
+  let testContainer;
+
+  beforeEach(() => {
+    testContainer = createTestContainer();
+  });
+
+  afterEach(() => {
+    tearDownTestContainer();
+  });
+
+  describe('#hideLoader()', () => {
+    it('finds the loader adds the hide class', () => {
+      const loader = document.createElement('div');
+      loader.setAttribute('id', 'loading');
+      testContainer.appendChild(loader);
+
+      hideLoader();
+
+      const actual = document.getElementById('loading');
+      expect(actual.className).toEqual('hide');
+    });
+  });
+
+  describe('#handleClickButton()', () => {
+    describe('when site is not found', () => {
+      it('adds visible class to alert', () => {
+        const data = [];
+        const container = document.createElement('div');
+        container.innerHTML = '<div id="alert"></div>' +
+            '<input id="site-id-input" type="tel" value="1"/>' +
+            '<input type="submit" name="submit" id="submit-button"/>';
+        testContainer.appendChild(container);
+
+        jasmine.clock().install();
+        handleClickButton(new Event('click'), data);
+        jasmine.clock().tick(50);
+
+        const actual = document.getElementById('alert');
+        expect(actual.className).toEqual('visible');
+      });
+    });
+
+    describe('when site is found', () => {
+      it('redirects to the site url', () => {
+        const data = [
+          {code: '1', url: 'something'}
+        ];
+        const container = document.createElement('div');
+        container.innerHTML = '<div id="alert"></div>' +
+            '<input id="site-id-input" type="tel" value="1"/>' +
+            '<input type="submit" name="submit" id="submit-button"/>';
+        testContainer.appendChild(container);
+
+
+        const redirectSpy = jasmine.createSpy();
+        handleClickButton(new Event('click'), data, redirectSpy);
+
+        expect(redirectSpy).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('#findSiteFromInput()', () => {
+    it('returns site when code from input exists in lookup data', () => {
+      const data = [
+        {code: '1234', url: 'something.com'}
+      ];
+      const input = {value: '1234'};
+
+      expect(findSiteFromInput(data, input)).toEqual(data[0]);
+    });
+
+    it('returns undefined when code from input does not exist in lookup data', () => {
+      const data = [
+        {code: '1234', url: 'something.com'}
+      ];
+      const input = {value: '1111'};
+
+      expect(findSiteFromInput(data, input)).toEqual(undefined);
+    });
+  });
+});

--- a/specHelper.js
+++ b/specHelper.js
@@ -1,0 +1,13 @@
+export function createTestContainer() {
+  const testContainer = document.createElement('div');
+  testContainer.setAttribute('id', 'test-container');
+  testContainer.setAttribute('style', "border: 2px solid red");
+  document.body.appendChild(testContainer);
+
+  return document.getElementById('test-container')
+}
+
+export function tearDownTestContainer() {
+  const testContainer = document.getElementById('test-container');
+  testContainer.parentNode.removeChild(testContainer);
+}


### PR DESCRIPTION
### Description

Adding unit tests for our JavaScript code. There's not a lot of JavaScript right now so this might be overkill, but adding a simple, browser compatible testing tool like Jasmine gives developers confidence to refactor the JS we have and determine if anything would actually break.

Adding tests specifically for the DOM manipulation specific JS code.

**Note**: I have no idea if we think this is actually necessary, since the project is so small, but this was definitely useful when cleaning up the index.js a bit.

### Type of change

* Test additions

### How Has This Been Tested?

1. Pull the branch locally
2. Open `SpecRunner.html` in your browser locally to run all tests
3. If all tests pass then all things should be good :+1:

### Screenshots

![image](https://user-images.githubusercontent.com/7366444/62007485-f12cf700-b11b-11e9-8179-b2b4393fdc26.png)
